### PR TITLE
oryol-conv3d IRepProcessor: Specifically include <algorithm>

### DIFF
--- a/src/oryol-conv3d/IRepProcessor.cc
+++ b/src/oryol-conv3d/IRepProcessor.cc
@@ -1,6 +1,8 @@
 //------------------------------------------------------------------------------
 //  IRepProcessor.cc
 //------------------------------------------------------------------------------
+#include <algorithm>
+
 #include "IRepProcessor.h"
 #include "LoadUtil.h"
 #include "cJSON.h"
@@ -36,7 +38,7 @@ IRepProcessor::Load(const string& path) {
     const char* str = (const char*) load_file(path);
     cJSON* json = cJSON_Parse(str);
     free_file_data((const uint8_t*)str);
-    Log::FailIf(!json, "Failed to parse JSON file '%s' with '%s'\n", path.c_str(), cJSON_GetErrorPtr()); 
+    Log::FailIf(!json, "Failed to parse JSON file '%s' with '%s'\n", path.c_str(), cJSON_GetErrorPtr());
     cJSON* node;
     if ((node = cJSONUtils_GetPointer(json, "/filter/nodes"))) {
         parseStringArray("/filter/nodes", node, this->Nodes);
@@ -52,7 +54,7 @@ static bool contains(const vector<string>& items, const string& item) {
 }
 
 //------------------------------------------------------------------------------
-static vector<string> 
+static vector<string>
 matchItems(const vector<string>& allItems, const vector<string>& filterItems) {
     // return a string vector with all items not in filter-items
     vector<string> res;

--- a/src/oryol-conv3d/OrbSaver.cc
+++ b/src/oryol-conv3d/OrbSaver.cc
@@ -1,6 +1,8 @@
 //------------------------------------------------------------------------------
 //  OrbSaver.cc
 //------------------------------------------------------------------------------
+#include <algorithm>
+
 #include "OrbSaver.h"
 #include "ExportUtil/Log.h"
 #include "ExportUtil/VertexCodec.h"
@@ -293,7 +295,7 @@ OrbSaver::Save(const std::string& path, const IRep& irep) {
             }
             fwrite(&dst, 1, sizeof(dst), fp);
         }
-    } 
+    }
 
     // write anim clips
     {


### PR DESCRIPTION
Fixes error: ‘find’ was not declared in this scope

```
/dir/oryol-tools/src/oryol-conv3d/IRepProcessor.cc:51:13: error: ‘find’ was not declared in this scope
     return (find(items.begin(), items.end(), item) != items.end());
             ^~~~
/dir/oryol-tools/src/oryol-conv3d/IRepProcessor.cc:51:13: note: suggested alternative: ‘rand’
     return (find(items.begin(), items.end(), item) != items.end());
             ^~~~
             rand
src/oryol-conv3d/CMakeFiles/oryol-conv3d.dir/build.make:110: recipe for target 'src/oryol-conv3d/CMakeFiles/oryol-conv3d.dir/IRepProcessor.cc.o' failed
/dir/oryol-tools/src/oryol-conv3d/OrbSaver.cc: In member function ‘uint32_t OrbSaver::addString(const string&)’:
/dir/oryol-tools/src/oryol-conv3d/OrbSaver.cc:16:28: error: ‘find’ is not a member of ‘std’
     ptrdiff_t index = std::find(strings.begin(), strings.end(), str) - strings.begin();
                            ^~~~
/dir/oryol-tools/src/oryol-conv3d/OrbSaver.cc:16:28: note: suggested alternative: ‘rint’
     ptrdiff_t index = std::find(strings.begin(), strings.end(), str) - strings.begin();
                            ^~~~
                            rint
src/oryol-conv3d/CMakeFiles/oryol-conv3d.dir/build.make:278: recipe for target 'src/oryol-conv3d/CMakeFiles/oryol-conv3d.dir/OrbSaver.cc.o' failed
```

Includes minor automatic whitespace cleanups.