### PR TITLE
update options for newer SPIRV-Cross version

### DIFF
--- a/src/oryol-shdc/main.cc
+++ b/src/oryol-shdc/main.cc
@@ -282,11 +282,11 @@ void write_reflection_json(Compiler* compiler, const string& out_path) {
 //------------------------------------------------------------------------------
 void to_glsl(const vector<uint32_t>& spirv, const string& out_path, uint32_t version, bool is_es) {
     CompilerGLSL compiler(spirv);
-    auto opts = compiler.get_options();
+    auto opts = compiler.get_common_options();
     opts.version = version;
     opts.es = is_es;
     opts.vertex.fixup_clipspace = false;
-    compiler.set_options(opts);
+    compiler.set_common_options(opts);
     fix_vertex_attr_locations(&compiler);
     fix_ub_matrix_force_colmajor(&compiler);
     flatten_uniform_blocks(&compiler);
@@ -303,11 +303,15 @@ void to_glsl(const vector<uint32_t>& spirv, const string& out_path, uint32_t ver
 //------------------------------------------------------------------------------
 void to_hlsl_sm5(const vector<uint32_t>& spirv, const string& out_path) {
     CompilerHLSL compiler(spirv);
-    auto opts = compiler.get_options();
+    
+    auto common_opts = compiler.get_common_options();
+    common_opts.vertex.fixup_clipspace = true;
+    compiler.set_common_options(common_opts);
+    
+    auto opts = compiler.get_hlsl_options();
     opts.shader_model = 50;
-    opts.fixup_clipspace = true;
     opts.point_size_compat = true;
-    compiler.set_options(opts);
+    compiler.set_hlsl_options(opts);
     fix_vertex_attr_locations(&compiler);
     fix_ub_matrix_force_colmajor(&compiler);
     write_reflection_json(&compiler, out_path + ".json");
@@ -323,9 +327,9 @@ void to_hlsl_sm5(const vector<uint32_t>& spirv, const string& out_path) {
 //------------------------------------------------------------------------------
 void to_mlsl(const vector<uint32_t>& spirv, const string& out_path) {
     CompilerMSL compiler(spirv);
-    auto opts = compiler.get_options();
-    opts.pad_and_pack_uniform_structs = true;
-    compiler.set_options(opts);
+    auto opts = compiler.get_msl_options();
+    //opts.pad_and_pack_uniform_structs = true;
+    compiler.set_msl_options(opts);
     fix_vertex_attr_locations(&compiler);
     write_reflection_json(&compiler, out_path + ".json");
     string src = compiler.compile();


### PR DESCRIPTION
I had some trouble using oryol with metal after upgrading to recent osx/xcode. Updating to the most recent SPIRV-Cross seemed to fix most of it (float[1]/clip_distance errors), this pull request contains some minor changes to handle change in the options api (opts.pad_and_pack_uniform_structs appears to have been removed, not sure).

Applying this change and also updating fips-sprirvcross to point to the latest seems to work. Additionally, I had to change the GLSL version in the shader compile scripts to use ver 420 so I could add "layout (location=0)" specifiers so that the vert/fragment shaders would link in metal, otherwise only very simple shaders would link if the "user(locN)" specifiers happened to line up, I don't know enough about spirv-cross to know if there's a better way to fix this.

Feel free to ignore this if you're not doing metal stuff or focusing on sokol, I just thought it might be helpful.